### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight wrapper for Apple's StoreKit, written in Swift.  
 
 [![CI Status](https://travis-ci.org/recisio/StoreKitCompanion.svg)](https://travis-ci.org/recisio/StoreKitCompanion)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/recisio/StoreKitCompanion.svg)](https://img.shields.io/cocoapods/v/StoreKitCompanion.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/recisio/StoreKitCompanion.svg)](https://img.shields.io/cocoapods/v/StoreKitCompanion.svg)
 [![Platform](https://img.shields.io/cocoapods/p/StoreKitCompanion.svg?style=flat)](http://cocoadocs.org/docsets/StoreKitCompanion)
 [![License](https://img.shields.io/cocoapods/l/StoreKitCompanion.svg?style=flat)](http://cocoapods.org/pods/StoreKitCompanion)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
